### PR TITLE
Integrate Google Analytics with vue-gtag for tracking

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 VITE_BASE_URL = 'https://color.yukai.dev'
+GA_MEASUREMENT_ID = 'G-9MTWCR6BWR'

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "nanoid": "^5.0.6",
         "tailwind-merge": "^3.0.2",
         "vue": "^3.4.21",
+        "vue-gtag": "^2.1.0",
         "vue-i18n": "^9.11.0",
         "vue-router": "4",
       },
@@ -940,6 +941,8 @@
     "vue": ["vue@3.4.21", "", { "dependencies": { "@vue/compiler-dom": "3.4.21", "@vue/compiler-sfc": "3.4.21", "@vue/runtime-dom": "3.4.21", "@vue/server-renderer": "3.4.21", "@vue/shared": "3.4.21" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA=="],
 
     "vue-demi": ["vue-demi@0.14.7", "", { "peerDependencies": { "@vue/composition-api": "^1.0.0-rc.1", "vue": "^3.0.0-0 || ^2.6.0" }, "optionalPeers": ["@vue/composition-api"], "bin": { "vue-demi-fix": "bin/vue-demi-fix.js", "vue-demi-switch": "bin/vue-demi-switch.js" } }, "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA=="],
+
+    "vue-gtag": ["vue-gtag@2.1.0", "", { "peerDependencies": { "vue": "^3.0.0" } }, "sha512-lnEiHtNkw37lUug36n023uYWRaFz7s2Wk12G+hdzrTKwWwTBuq0Mcd5e0zH65aKPZRWT+51C6LUHZShpTPiMng=="],
 
     "vue-i18n": ["vue-i18n@9.11.0", "", { "dependencies": { "@intlify/core-base": "9.11.0", "@intlify/shared": "9.11.0", "@vue/devtools-api": "^6.5.0" }, "peerDependencies": { "vue": "^3.0.0" } }, "sha512-vU4gY6lu8Pdfs9BgKGiDAJmFDf88cceR47KcSB0VW4xJzUrXR/7qwqM7A8dQ2nedhoIDxoOm5Ro4pFd2KvJqbA=="],
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"nanoid": "^5.0.6",
 		"tailwind-merge": "^3.0.2",
 		"vue": "^3.4.21",
+		"vue-gtag": "^2.1.0",
 		"vue-i18n": "^9.11.0",
 		"vue-router": "4"
 	},

--- a/src/main.js
+++ b/src/main.js
@@ -18,8 +18,8 @@ app
 	.use(
 		VueGtag,
 		{
-      appName: 'Chami Match',
-      pageTrackerScreenviewEnabled: true,
+			appName: "Chami Match",
+			pageTrackerScreenviewEnabled: true,
 			config: { id: import.meta.env.GA_MEASUREMENT_ID },
 		},
 		router,

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import { createHead } from "@unhead/vue";
 import { createApp } from "vue";
+import VueGtag from "vue-gtag";
 
 import "./style.css";
 import App from "./App.vue";
@@ -10,6 +11,18 @@ const head = createHead();
 
 const app = createApp(App);
 
-app.use(i18n).use(head).use(router);
+app
+	.use(i18n)
+	.use(head)
+	.use(router)
+	.use(
+		VueGtag,
+		{
+      appName: 'Chami Match',
+      pageTrackerScreenviewEnabled: true,
+			config: { id: import.meta.env.GA_MEASUREMENT_ID },
+		},
+		router,
+	);
 
 app.mount("#app");


### PR DESCRIPTION
Add Google Analytics tracking to the application using vue-gtag, including necessary configuration and dependencies.