### PR TITLE
Add RGB and OKLAB color space support in RecordPopup

### DIFF
--- a/src/components/GameScreen.vue
+++ b/src/components/GameScreen.vue
@@ -10,6 +10,11 @@ const mode = computed(() => store.mode);
 const colorSpace = computed(() => store.colorSpace);
 const realtimePreview = computed(() => store.realtimePreview);
 
+// start a new round if current round is zero
+if (store.currentRound === 0) {
+  store.startNewRound();
+}
+
 // HSV values
 const userH = ref(store.userColor?.h || 0);
 const userS = ref(store.userColor?.s || 0);

--- a/src/components/GameScreen.vue
+++ b/src/components/GameScreen.vue
@@ -12,7 +12,7 @@ const realtimePreview = computed(() => store.realtimePreview);
 
 // start a new round if current round is zero
 if (store.currentRound === 0) {
-  store.startNewRound();
+	store.startNewRound();
 }
 
 // HSV values

--- a/src/components/RecordPopup.vue
+++ b/src/components/RecordPopup.vue
@@ -458,13 +458,22 @@ function formatGameType(type) {
 
 // Helper function to determine color format
 function getColorFormat(record) {
-	if (!record?.actualColor) return "HSV";
-	if ('r' in record.actualColor && 'g' in record.actualColor && 'b' in record.actualColor) {
-		return "RGB";
-	} else if ('L' in record.actualColor && 'a' in record.actualColor && 'b' in record.actualColor) {
-		return "OKLAB";
-	}
-	return "HSV";
+  if (!record?.actualColor) return "HSV";
+
+  // More precise format detection
+  if ('L' in record.actualColor && 'a' in record.actualColor && 'b' in record.actualColor) {
+    // OKLAB has specific L, a, b properties
+    return "OKLAB";
+  } else if ('r' in record.actualColor && 'g' in record.actualColor && 'b' in record.actualColor) {
+    // RGB has specific r, g, b properties
+    return "RGB";
+  } else if ('h' in record.actualColor && 's' in record.actualColor && 'v' in record.actualColor) {
+    // HSV has specific h, s, v properties
+    return "HSV";
+  }
+
+  // If we can't determine format, look for colorSpace property
+  return record.colorSpace?.toUpperCase() || "HSV";
 }
 
 // Convert any color to HSV for comparison

--- a/src/components/RecordPopup.vue
+++ b/src/components/RecordPopup.vue
@@ -356,10 +356,26 @@ function formatGameType(type) {
 function getColorStyle(color) {
 	if (!color) return "background-color: gray;";
 
+	// Handle RGB color space
+	if ('r' in color && 'g' in color && 'b' in color) {
+		const r = color.r ?? 0;
+		const g = color.g ?? 0;
+		const b = color.b ?? 0;
+		return `background-color: rgb(${r}, ${g}, ${b});`;
+	}
+
+	// Handle OKLAB color space
+	if ('L' in color && 'a' in color && 'b' in color) {
+		const L = color.L ?? 0;
+		const a = color.a ?? 0;
+		const b = color.b ?? 0;
+		return `background-color: oklab(${L} ${a} ${b});`;
+	}
+
+	// Default to HSV color space
 	const h = color.h ?? 0;
 	const s = color.s ?? 0;
 	const v = color.v ?? 0;
-
 	return `background-color: hsl(${h}, ${s}%, ${v}%);`;
 }
 

--- a/src/components/RecordPopup.vue
+++ b/src/components/RecordPopup.vue
@@ -502,21 +502,28 @@ function convertToHsv(color) {
 function getColorStyle(color) {
 	if (!color) return "background-color: gray;";
 
+  // Handle OKLAB color space
+  if ('L' in color && 'a' in color && 'b' in color) {
+    const L = color.L ?? 0;
+    const a = color.a ?? 0;
+    const b = color.b ?? 0;
+
+    // Convert from our sliders' range (-100 to 100) to CSS oklab() range (-0.4 to 0.4)
+    // L is already properly scaled (0-100 to 0-1) by dividing by 100
+    // But a and b need to be scaled from -100/+100 to -0.4/+0.4
+    const cssL = L / 100;
+    const cssA = a / 250; // Scale from -100/+100 to -0.4/+0.4
+    const cssB = b / 250; // Scale from -100/+100 to -0.4/+0.4
+
+    return `background-color: oklab(${cssL} ${cssA} ${cssB});`;
+  }
+
 	// Handle RGB color space
 	if ('r' in color && 'g' in color && 'b' in color) {
 		const r = color.r ?? 0;
 		const g = color.g ?? 0;
 		const b = color.b ?? 0;
 		return `background-color: rgb(${r}, ${g}, ${b});`;
-	}
-
-	// Handle OKLAB color space
-	if ('L' in color && 'a' in color && 'b' in color) {
-		const L = color.L ?? 0;
-		const a = color.a ?? 0;
-		const b = color.b ?? 0;
-		// For display, convert OKLAB to RGB using CSS oklch()
-		return `background-color: oklab(${L/100} ${a/100} ${b/100});`;
 	}
 
 	// Default to HSV color space

--- a/src/components/RecordPopup.vue
+++ b/src/components/RecordPopup.vue
@@ -112,44 +112,129 @@
                     <div class="text-gray-800 dark:text-white">{{ $t('precisionTarget') }}: ±{{ record.session?.precision || 10 }}</div>
                   </div>
 
-                  <!-- Hue difference -->
-                  <div class="flex items-center gap-2">
-                    <div class="w-6 font-mono text-pink-600 dark:text-pink-300">H:</div>
-                    <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-300 dark:bg-gray-700">
-                      <div
-                        class="h-full"
-                        :class="getColorDifferenceClass(getHueDifference(record))"
-                        :style="`width: ${Math.min(100, getHueDifference(record))}%`"
-                      ></div>
+                  <!-- Display color differences based on color space -->
+                  <template v-if="getColorFormat(record) === 'RGB'">
+                    <!-- RGB differences -->
+                    <div class="flex items-center gap-2">
+                      <div class="w-6 font-mono text-red-600 dark:text-red-300">R:</div>
+                      <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-300 dark:bg-gray-700">
+                        <div
+                          class="h-full"
+                          :class="getColorDifferenceClass(getRgbDifference(record, 'r'))"
+                          :style="`width: ${Math.min(100, getRgbDifference(record, 'r'))}%`"
+                        ></div>
+                      </div>
+                      <div class="w-12 text-right font-mono text-xs text-gray-800 dark:text-white">{{ formatDifference(getRgbDifference(record, 'r')) }}</div>
                     </div>
-                    <div class="w-12 text-right font-mono text-xs text-gray-800 dark:text-white">{{ formatDifference(getHueDifference(record)) }}</div>
-                  </div>
 
-                  <!-- Saturation difference -->
-                  <div class="flex items-center gap-2">
-                    <div class="w-6 font-mono text-pink-600 dark:text-pink-300">S:</div>
-                    <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-300 dark:bg-gray-700">
-                      <div
-                        class="h-full"
-                        :class="getColorDifferenceClass(getSaturationDifference(record))"
-                        :style="`width: ${Math.min(100, getSaturationDifference(record))}%`"
-                      ></div>
+                    <!-- Green difference -->
+                    <div class="flex items-center gap-2">
+                      <div class="w-6 font-mono text-green-600 dark:text-green-300">G:</div>
+                      <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-300 dark:bg-gray-700">
+                        <div
+                          class="h-full"
+                          :class="getColorDifferenceClass(getRgbDifference(record, 'g'))"
+                          :style="`width: ${Math.min(100, getRgbDifference(record, 'g'))}%`"
+                        ></div>
+                      </div>
+                      <div class="w-12 text-right font-mono text-xs text-gray-800 dark:text-white">{{ formatDifference(getRgbDifference(record, 'g')) }}</div>
                     </div>
-                    <div class="w-12 text-right font-mono text-xs text-gray-800 dark:text-white">{{ formatDifference(getSaturationDifference(record)) }}</div>
-                  </div>
 
-                  <!-- Value difference -->
-                  <div class="flex items-center gap-2">
-                    <div class="w-6 font-mono text-pink-600 dark:text-pink-300">V:</div>
-                    <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-300 dark:bg-gray-700">
-                      <div
-                        class="h-full"
-                        :class="getColorDifferenceClass(getValueDifference(record))"
-                        :style="`width: ${Math.min(100, getValueDifference(record))}%`"
-                      ></div>
+                    <!-- Blue difference -->
+                    <div class="flex items-center gap-2">
+                      <div class="w-6 font-mono text-blue-600 dark:text-blue-300">B:</div>
+                      <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-300 dark:bg-gray-700">
+                        <div
+                          class="h-full"
+                          :class="getColorDifferenceClass(getRgbDifference(record, 'b'))"
+                          :style="`width: ${Math.min(100, getRgbDifference(record, 'b'))}%`"
+                        ></div>
+                      </div>
+                      <div class="w-12 text-right font-mono text-xs text-gray-800 dark:text-white">{{ formatDifference(getRgbDifference(record, 'b')) }}</div>
                     </div>
-                    <div class="w-12 text-right font-mono text-xs text-gray-800 dark:text-white">{{ formatDifference(getValueDifference(record)) }}</div>
-                  </div>
+                  </template>
+
+                  <template v-else-if="getColorFormat(record) === 'OKLAB'">
+                    <!-- OKLAB differences -->
+                    <div class="flex items-center gap-2">
+                      <div class="w-6 font-mono text-purple-600 dark:text-purple-300">L:</div>
+                      <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-300 dark:bg-gray-700">
+                        <div
+                          class="h-full"
+                          :class="getColorDifferenceClass(getOklabDifference(record, 'L'))"
+                          :style="`width: ${Math.min(100, getOklabDifference(record, 'L'))}%`"
+                        ></div>
+                      </div>
+                      <div class="w-12 text-right font-mono text-xs text-gray-800 dark:text-white">{{ formatDifference(getOklabDifference(record, 'L')) }}</div>
+                    </div>
+
+                    <!-- a-axis difference -->
+                    <div class="flex items-center gap-2">
+                      <div class="w-6 font-mono text-emerald-600 dark:text-emerald-300">a:</div>
+                      <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-300 dark:bg-gray-700">
+                        <div
+                          class="h-full"
+                          :class="getColorDifferenceClass(getOklabDifference(record, 'a'))"
+                          :style="`width: ${Math.min(100, getOklabDifference(record, 'a'))}%`"
+                        ></div>
+                      </div>
+                      <div class="w-12 text-right font-mono text-xs text-gray-800 dark:text-white">{{ formatDifference(getOklabDifference(record, 'a')) }}</div>
+                    </div>
+
+                    <!-- b-axis difference -->
+                    <div class="flex items-center gap-2">
+                      <div class="w-6 font-mono text-amber-600 dark:text-amber-300">b:</div>
+                      <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-300 dark:bg-gray-700">
+                        <div
+                          class="h-full"
+                          :class="getColorDifferenceClass(getOklabDifference(record, 'b'))"
+                          :style="`width: ${Math.min(100, getOklabDifference(record, 'b'))}%`"
+                        ></div>
+                      </div>
+                      <div class="w-12 text-right font-mono text-xs text-gray-800 dark:text-white">{{ formatDifference(getOklabDifference(record, 'b')) }}</div>
+                    </div>
+                  </template>
+
+                  <template v-else>
+                    <!-- Default HSV differences -->
+                    <div class="flex items-center gap-2">
+                      <div class="w-6 font-mono text-pink-600 dark:text-pink-300">H:</div>
+                      <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-300 dark:bg-gray-700">
+                        <div
+                          class="h-full"
+                          :class="getColorDifferenceClass(getHueDifference(record))"
+                          :style="`width: ${Math.min(100, getHueDifference(record))}%`"
+                        ></div>
+                      </div>
+                      <div class="w-12 text-right font-mono text-xs text-gray-800 dark:text-white">{{ formatDifference(getHueDifference(record)) }}</div>
+                    </div>
+
+                    <!-- Saturation difference -->
+                    <div class="flex items-center gap-2">
+                      <div class="w-6 font-mono text-pink-600 dark:text-pink-300">S:</div>
+                      <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-300 dark:bg-gray-700">
+                        <div
+                          class="h-full"
+                          :class="getColorDifferenceClass(getSaturationDifference(record))"
+                          :style="`width: ${Math.min(100, getSaturationDifference(record))}%`"
+                        ></div>
+                      </div>
+                      <div class="w-12 text-right font-mono text-xs text-gray-800 dark:text-white">{{ formatDifference(getSaturationDifference(record)) }}</div>
+                    </div>
+
+                    <!-- Value difference -->
+                    <div class="flex items-center gap-2">
+                      <div class="w-6 font-mono text-pink-600 dark:text-pink-300">V:</div>
+                      <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-300 dark:bg-gray-700">
+                        <div
+                          class="h-full"
+                          :class="getColorDifferenceClass(getValueDifference(record))"
+                          :style="`width: ${Math.min(100, getValueDifference(record))}%`"
+                        ></div>
+                      </div>
+                      <div class="w-12 text-right font-mono text-xs text-gray-800 dark:text-white">{{ formatDifference(getValueDifference(record)) }}</div>
+                    </div>
+                  </template>
                 </div>
               </template>
             </template>
@@ -477,6 +562,30 @@ function getValueDifference(record) {
 	const guessedHsv = convertToHsv(record.guessedColor);
 
 	return Math.abs(actualHsv.v - guessedHsv.v);
+}
+
+// Helper functions to calculate RGB color differences
+function getRgbDifference(record, channel) {
+  if (!record?.actualColor?.[channel] || !record?.guessedColor?.[channel]) return 0;
+
+  // Calculate percentage difference (0-100%) from the 0-255 range
+  const diff = Math.abs(record.actualColor[channel] - record.guessedColor[channel]);
+  return (diff / 2.55); // Convert to percentage (255/100 = 2.55)
+}
+
+// Helper functions to calculate OKLAB color differences
+function getOklabDifference(record, channel) {
+  if (!record?.actualColor?.[channel] || !record?.guessedColor?.[channel]) return 0;
+
+  // Calculate percentage difference
+  // For L: 0-100 is already percentage
+  // For a & b: -100 to +100 range needs to be converted to percentage
+  if (channel === 'L') {
+    return Math.abs(record.actualColor[channel] - record.guessedColor[channel]);
+  } else {
+    // a and b range from -100 to +100, so divide by 2 to get percentage
+    return Math.abs(record.actualColor[channel] - record.guessedColor[channel]) / 2;
+  }
 }
 
 // Format difference to show + or - prefix

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -162,7 +162,7 @@ export const useGameStore = defineStore("game", {
 
 				// Process all records from history
 				state.history.forEach((record) => {
-					if (!record || !record.sessionId || typeof record.round === 'undefined') return;
+					if (!record || !record.sessionId || !record.round) return;
 
 					// Initialize session if needed
 					if (!recordsBySession[record.sessionId]) {

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -162,7 +162,7 @@ export const useGameStore = defineStore("game", {
 
 				// Process all records from history
 				state.history.forEach((record) => {
-					if (!record || !record.sessionId || !record.round) return;
+					if (!record || !record.sessionId || typeof record.round === 'undefined') return;
 
 					// Initialize session if needed
 					if (!recordsBySession[record.sessionId]) {

--- a/src/stores/modes/StandardMode.js
+++ b/src/stores/modes/StandardMode.js
@@ -124,20 +124,20 @@ export class StandardMode extends BaseMode {
 			currentHsv = rgbToHsv(
 				this.state.randomColor.r,
 				this.state.randomColor.g,
-				this.state.randomColor.b
+				this.state.randomColor.b,
 			);
 		} else if (this.colorSpace === "oklab") {
 			currentHsv = oklabToHsv(
 				this.state.randomColor.L,
 				this.state.randomColor.a,
-				this.state.randomColor.b
+				this.state.randomColor.b,
 			);
 		} else {
 			// Already HSV
 			currentHsv = {
 				h: this.state.randomColor.h,
 				s: this.state.randomColor.s,
-				v: this.state.randomColor.v
+				v: this.state.randomColor.v,
 			};
 		}
 
@@ -162,12 +162,12 @@ export class StandardMode extends BaseMode {
 		}
 
 		// Clear existing properties from randomColor
-		Object.keys(this.state.randomColor).forEach(key => {
+		Object.keys(this.state.randomColor).forEach((key) => {
 			delete this.state.randomColor[key];
 		});
 
 		// Set new properties based on color space
-		Object.keys(newColor).forEach(key => {
+		Object.keys(newColor).forEach((key) => {
 			this.state.randomColor[key] = newColor[key];
 		});
 	}
@@ -175,42 +175,42 @@ export class StandardMode extends BaseMode {
 	checkGuess() {
 		const precision = this.options.precision || 10;
 
-			// Check based on the current color space
-			if (this.colorSpace === "rgb") {
-				// Compare RGB values directly
-				const targetRgb = this.state.randomColor;
-				const userRgb = this.state.userColor;
+		// Check based on the current color space
+		if (this.colorSpace === "rgb") {
+			// Compare RGB values directly
+			const targetRgb = this.state.randomColor;
+			const userRgb = this.state.userColor;
 
-				// Calculate percentage differences for RGB (0-255 scale)
-				const rDiff = Math.abs(targetRgb.r - userRgb.r) / 2.55; // Convert to percentage
-				const gDiff = Math.abs(targetRgb.g - userRgb.g) / 2.55;
-				const bDiff = Math.abs(targetRgb.b - userRgb.b) / 2.55;
+			// Calculate percentage differences for RGB (0-255 scale)
+			const rDiff = Math.abs(targetRgb.r - userRgb.r) / 2.55; // Convert to percentage
+			const gDiff = Math.abs(targetRgb.g - userRgb.g) / 2.55;
+			const bDiff = Math.abs(targetRgb.b - userRgb.b) / 2.55;
 
-				return rDiff <= precision && gDiff <= precision && bDiff <= precision;
-			}
+			return rDiff <= precision && gDiff <= precision && bDiff <= precision;
+		}
 
-			if (this.colorSpace === "oklab") {
-				// Compare OKLAB values directly
-				const targetLab = this.state.randomColor;
-				const userLab = this.state.userColor;
+		if (this.colorSpace === "oklab") {
+			// Compare OKLAB values directly
+			const targetLab = this.state.randomColor;
+			const userLab = this.state.userColor;
 
-				// For OKLAB, L is 0-100, a and b are -100 to +100
-				const LDiff = Math.abs(targetLab.L - userLab.L); // Already percentage
-				const aDiff = Math.abs(targetLab.a - userLab.a) / 2; // Convert to percentage (200 range)
-				const bDiff = Math.abs(targetLab.b - userLab.b) / 2;
+			// For OKLAB, L is 0-100, a and b are -100 to +100
+			const LDiff = Math.abs(targetLab.L - userLab.L); // Already percentage
+			const aDiff = Math.abs(targetLab.a - userLab.a) / 2; // Convert to percentage (200 range)
+			const bDiff = Math.abs(targetLab.b - userLab.b) / 2;
 
-				return LDiff <= precision && aDiff <= precision && bDiff <= precision;
-			}
+			return LDiff <= precision && aDiff <= precision && bDiff <= precision;
+		}
 
-			// Default HSV comparison
-			const hIsGood =
-				Math.abs(this.state.randomColor.h - this.state.userColor.h) <= precision;
-			const sIsGood =
-				Math.abs(this.state.randomColor.s - this.state.userColor.s) <= precision;
-			const vIsGood =
-				Math.abs(this.state.randomColor.v - this.state.userColor.v) <= precision;
+		// Default HSV comparison
+		const hIsGood =
+			Math.abs(this.state.randomColor.h - this.state.userColor.h) <= precision;
+		const sIsGood =
+			Math.abs(this.state.randomColor.s - this.state.userColor.s) <= precision;
+		const vIsGood =
+			Math.abs(this.state.randomColor.v - this.state.userColor.v) <= precision;
 
-			return hIsGood && sIsGood && vIsGood;
+		return hIsGood && sIsGood && vIsGood;
 	}
 
 	createHistoryRecord(wasSuccess, round, sessionId) {
@@ -224,36 +224,36 @@ export class StandardMode extends BaseMode {
 			actualColor = {
 				h: this.state.randomColor.h,
 				s: this.state.randomColor.s,
-				v: this.state.randomColor.v
+				v: this.state.randomColor.v,
 			};
 			guessedColor = {
 				h: this.state.userColor.h,
 				s: this.state.userColor.s,
-				v: this.state.userColor.v
+				v: this.state.userColor.v,
 			};
 		} else if (this.colorSpace === "rgb") {
 			// For RGB, include only r, g, b properties
 			actualColor = {
 				r: this.state.randomColor.r,
 				g: this.state.randomColor.g,
-				b: this.state.randomColor.b
+				b: this.state.randomColor.b,
 			};
 			guessedColor = {
 				r: this.state.userColor.r,
 				g: this.state.userColor.g,
-				b: this.state.userColor.b
+				b: this.state.userColor.b,
 			};
 		} else if (this.colorSpace === "oklab") {
 			// For OKLAB, include only L, a, b properties
 			actualColor = {
 				L: this.state.randomColor.L,
 				a: this.state.randomColor.a,
-				b: this.state.randomColor.b
+				b: this.state.randomColor.b,
 			};
 			guessedColor = {
 				L: this.state.userColor.L,
 				a: this.state.userColor.a,
-				b: this.state.userColor.b
+				b: this.state.userColor.b,
 			};
 		}
 
@@ -262,7 +262,7 @@ export class StandardMode extends BaseMode {
 			type: "color",
 			guessedColor,
 			actualColor,
-			colorSpace: this.colorSpace // Store the color space used
+			colorSpace: this.colorSpace, // Store the color space used
 		};
 	}
 }

--- a/src/stores/modes/StandardMode.js
+++ b/src/stores/modes/StandardMode.js
@@ -61,12 +61,12 @@ export class StandardMode extends BaseMode {
 		if (this.colorSpace === "rgb") {
 			// Convert HSV to RGB
 			const { r, g, b } = this.hsvToRgb(hsvColor.h, hsvColor.s, hsvColor.v);
-			return { r, g, b, _hsv: hsvColor }; // Keep the original HSV for comparison
+			return { r, g, b }; // Return only RGB values
 		}
 		if (this.colorSpace === "oklab") {
 			// Convert HSV to OKLAB
 			const { L, a, b } = hsvToOklab(hsvColor.h, hsvColor.s, hsvColor.v);
-			return { L, a, b, _hsv: hsvColor }; // Keep the original HSV for comparison
+			return { L, a, b }; // Return only OKLAB values
 		}
 		return hsvColor; // Default to HSV
 	}
@@ -85,12 +85,10 @@ export class StandardMode extends BaseMode {
 			this.state.randomColor.r = random.r;
 			this.state.randomColor.g = random.g;
 			this.state.randomColor.b = random.b;
-			this.state.randomColor._hsv = random._hsv; // Store original HSV for comparison
 		} else if (this.colorSpace === "oklab") {
 			this.state.randomColor.L = random.L;
 			this.state.randomColor.a = random.a;
 			this.state.randomColor.b = random.b;
-			this.state.randomColor._hsv = random._hsv; // Store original HSV for comparison
 		} else {
 			// Default to HSV
 			this.state.randomColor.h = random.h;
@@ -118,6 +116,32 @@ export class StandardMode extends BaseMode {
 
 	// Set the color space
 	setColorSpace(colorSpace) {
+		// Store the current color values in HSV for conversion
+		let currentHsv;
+
+		// Convert current color to HSV for transition
+		if (this.colorSpace === "rgb") {
+			currentHsv = rgbToHsv(
+				this.state.randomColor.r,
+				this.state.randomColor.g,
+				this.state.randomColor.b
+			);
+		} else if (this.colorSpace === "oklab") {
+			currentHsv = oklabToHsv(
+				this.state.randomColor.L,
+				this.state.randomColor.a,
+				this.state.randomColor.b
+			);
+		} else {
+			// Already HSV
+			currentHsv = {
+				h: this.state.randomColor.h,
+				s: this.state.randomColor.s,
+				v: this.state.randomColor.v
+			};
+		}
+
+		// Update the color space
 		this.colorSpace = colorSpace;
 		this.state.colorSpace = colorSpace;
 
@@ -127,21 +151,25 @@ export class StandardMode extends BaseMode {
 			this.state.userColor[key] = defaultColor[key];
 		});
 
-		// Convert the random color to the new color space
-		const randomHsv = this.state.randomColor._hsv || this.state.randomColor;
-		const newRandom = this.generateRandomColor();
+		// Convert the current color to the new color space
+		let newColor;
+		if (colorSpace === "rgb") {
+			newColor = hsvToRgb(currentHsv.h, currentHsv.s, currentHsv.v);
+		} else if (colorSpace === "oklab") {
+			newColor = hsvToOklab(currentHsv.h, currentHsv.s, currentHsv.v);
+		} else {
+			newColor = currentHsv;
+		}
 
-		// Update the random color for the new color space
-		Object.keys(newRandom).forEach((key) => {
-			if (key !== "_hsv") {
-				this.state.randomColor[key] = newRandom[key];
-			}
+		// Clear existing properties from randomColor
+		Object.keys(this.state.randomColor).forEach(key => {
+			delete this.state.randomColor[key];
 		});
 
-		// Keep the original HSV for comparison
-		if (this.colorSpace !== "hsv") {
-			this.state.randomColor._hsv = randomHsv;
-		}
+		// Set new properties based on color space
+		Object.keys(newColor).forEach(key => {
+			this.state.randomColor[key] = newColor[key];
+		});
 	}
 
 	checkGuess() {
@@ -186,19 +214,54 @@ export class StandardMode extends BaseMode {
 	}
 
 	createHistoryRecord(wasSuccess, round, sessionId) {
-		// Create a clean copy of the random color, excluding the _hsv property
-		const actualColor = {};
-		Object.keys(this.state.randomColor).forEach(key => {
-			if (key !== '_hsv') {
-				actualColor[key] = this.state.randomColor[key];
-			}
-		});
+		// Create filtered copies of the colors based on the active color space
+		let actualColor = {};
+		let guessedColor = {};
+
+		// Select only the properties relevant to the current color space
+		if (this.colorSpace === "hsv") {
+			// For HSV, include only h, s, v properties
+			actualColor = {
+				h: this.state.randomColor.h,
+				s: this.state.randomColor.s,
+				v: this.state.randomColor.v
+			};
+			guessedColor = {
+				h: this.state.userColor.h,
+				s: this.state.userColor.s,
+				v: this.state.userColor.v
+			};
+		} else if (this.colorSpace === "rgb") {
+			// For RGB, include only r, g, b properties
+			actualColor = {
+				r: this.state.randomColor.r,
+				g: this.state.randomColor.g,
+				b: this.state.randomColor.b
+			};
+			guessedColor = {
+				r: this.state.userColor.r,
+				g: this.state.userColor.g,
+				b: this.state.userColor.b
+			};
+		} else if (this.colorSpace === "oklab") {
+			// For OKLAB, include only L, a, b properties
+			actualColor = {
+				L: this.state.randomColor.L,
+				a: this.state.randomColor.a,
+				b: this.state.randomColor.b
+			};
+			guessedColor = {
+				L: this.state.userColor.L,
+				a: this.state.userColor.a,
+				b: this.state.userColor.b
+			};
+		}
 
 		// Include color space information in the record
 		return {
 			type: "color",
-			guessedColor: Object.assign({}, this.state.userColor),
-			actualColor: actualColor,
+			guessedColor,
+			actualColor,
 			colorSpace: this.colorSpace // Store the color space used
 		};
 	}


### PR DESCRIPTION
Introduce support for RGB and OKLAB color spaces in the RecordPopup component, enhance color format detection, and streamline color comparison logic. Automatically start a new round when the current round is zero and improve history record validation by including color space information.