### PR TITLE
Fix: Remove quick start button

### DIFF
--- a/src/components/WelcomeScreen.vue
+++ b/src/components/WelcomeScreen.vue
@@ -162,19 +162,6 @@ onMounted(() => {
         </BaseButton>
       </div>
 
-      <!-- Quick start last played game -->
-      <div v-if="store.lastPlayedGameType &&
-                 store.lastPlayedGameType !== currentGameMode.type"
-           class="mt-4">
-        <BaseButton
-          variant="primary"
-          full-width
-          @click="quickStartLastGame"
-        >
-          {{ $t('quickStart') }}
-        </BaseButton>
-      </div>
-
       <!-- Settings and About buttons -->
       <div class="mt-4 flex flex-col gap-2">
         <BaseButton


### PR DESCRIPTION
Removes the 'Quick start last played game' button from the welcome screen as the functionality is now default.

Closes #79